### PR TITLE
Refactor and prevent bogus lighting modes values.

### DIFF
--- a/src/utils/vrad/vrad.cpp
+++ b/src/utils/vrad/vrad.cpp
@@ -9,6 +9,7 @@
 // vrad.c
 
 #include "vrad.h"
+#include "vraddetailprops.h"
 #include "physdll.h"
 #include "lightmap.h"
 #include "tier1/strtools.h"
@@ -2413,6 +2414,12 @@ int ParseCommandLine( int argc, char **argv, bool *onlydetail )
 			if ( ++i < argc )
 			{
 				g_nIndirectPropLightingMode = atoi( argv[i] );
+
+				if ( g_nIndirectPropLightingMode < 0 || g_nIndirectPropLightingMode > LIGHTMODE_INDIRECT_LAST )
+				{
+					Warning( "Error: expected ranged value (0..%d) after '-StaticPropIndirectMode'\n", LIGHTMODE_INDIRECT_LAST );
+					return -1;
+				}
 			}
 			else
 			{

--- a/src/utils/vrad/vrad.cpp
+++ b/src/utils/vrad/vrad.cpp
@@ -119,7 +119,7 @@ bool		g_bStaticPropLighting = false;
 bool        g_bStaticPropPolys = false;
 bool        g_bTextureShadows = false;
 bool        g_bDisablePropSelfShadowing = false;
-
+int			g_nIndirectPropLightingMode = 0;
 
 CUtlVector<byte> g_FacesVisibleToLights;
 
@@ -2408,6 +2408,18 @@ int ParseCommandLine( int argc, char **argv, bool *onlydetail )
 		{
 			g_bDisablePropSelfShadowing = true;
 		}
+		else if ( !Q_stricmp( argv[i], "-StaticPropIndirectMode" ) )
+		{
+			if ( ++i < argc )
+			{
+				g_nIndirectPropLightingMode = atoi( argv[i] );
+			}
+			else
+			{
+				Warning( "Error: expected a value after '-StaticPropIndirectMode'\n" );
+				return -1;
+			}
+		}
 		else if ( !Q_stricmp( argv[i], "-textureshadows" ) )
 		{
 			g_bTextureShadows = true;
@@ -2871,6 +2883,7 @@ void PrintUsage( int argc, char **argv )
 		"                          light across a wider area.\n"
         "  -StaticPropLighting   : generate backed static prop vertex lighting\n"
         "  -StaticPropPolys   : Perform shadow tests of static props at polygon precision\n"
+		"  -StaticPropIndirectMode : Override prop indirect lighting algorithm (0 - default, 1 - TF2, 2 - Orangebox)\n"
         "  -OnlyStaticProps   : Only perform direct static prop lighting (vrad debug option)\n"
 		"  -StaticPropNormals : when lighting static props, just show their normal vector\n"
 		"  -textureshadows : Allows texture alpha channels to block light - rays intersecting alpha surfaces will sample the texture\n"

--- a/src/utils/vrad/vrad.h
+++ b/src/utils/vrad/vrad.h
@@ -290,6 +290,7 @@ extern bool g_bStaticPropPolys;
 extern bool g_bTextureShadows;
 extern bool g_bShowStaticPropNormals;
 extern bool g_bDisablePropSelfShadowing;
+extern int g_nIndirectPropLightingMode;
 
 extern CUtlVector<char const *> g_NonShadowCastingMaterialStrings;
 extern void ForceTextureShadowsOnModel( const char *pModelName );

--- a/src/utils/vrad/vraddetailprops.cpp
+++ b/src/utils/vrad/vraddetailprops.cpp
@@ -753,26 +753,28 @@ void ComputeIndirectLightingAtPoint( Vector &position, Vector &normal, Vector &o
 		// Mode 2: Orangebox (and earlier)
 		// Here, indirect lighting simply took the reflectivity and did not factor in falloff or dot.
 		// This created an unnaturally bright result, but this is what TF2 shipped with on release.
+		Vector vReflectivity = dtexdata[pTex->texdata].reflectivity;
 		switch ( g_nIndirectPropLightingMode )
 		{
 			case 0:
-			{
-				VectorMultiply( lightmapColor, dot * dtexdata[pTex->texdata].reflectivity, lightmapColor );
+				// Dot product.
+				vReflectivity *= dot;
 				break;
-			}
+
 			case 1:
-			{
-				float invLengthSqr = 1.0f / ( 1.0f + ( ( vEnd - position ) * surfEnum.m_HitFrac / 128.0 ).LengthSqr() );
-				VectorMultiply( lightmapColor, invLengthSqr * dtexdata[pTex->texdata].reflectivity, lightmapColor );
+				// Inverse square law.
+				vReflectivity *= ( 1.0f / ( 1.0f + ( ( vEnd - position ) * surfEnum.m_HitFrac / 128.0 ).LengthSqr() ) );
 				break;
-			}
+
 			case 2:
-			{
-				VectorMultiply( lightmapColor, dtexdata[pTex->texdata].reflectivity, lightmapColor );
+				// No modifications.
 				break;
-			}
+
+			default:
+				Assert( 0 );
 		}
 
+		VectorMultiply( lightmapColor, vReflectivity, lightmapColor );
 		VectorAdd( outColor, lightmapColor, outColor );
 	}
 

--- a/src/utils/vrad/vraddetailprops.cpp
+++ b/src/utils/vrad/vraddetailprops.cpp
@@ -756,18 +756,15 @@ void ComputeIndirectLightingAtPoint( Vector &position, Vector &normal, Vector &o
 		Vector vReflectivity = dtexdata[pTex->texdata].reflectivity;
 		switch ( g_nIndirectPropLightingMode )
 		{
-			case 0:
-				// Dot product.
+			case LIGHTMODE_INDIRECT_DOT:
 				vReflectivity *= dot;
 				break;
 
-			case 1:
-				// Inverse square law.
+			case LIGHTMODE_INDIRECT_INVSQRLAW:
 				vReflectivity *= ( 1.0f / ( 1.0f + ( ( vEnd - position ) * surfEnum.m_HitFrac / 128.0 ).LengthSqr() ) );
 				break;
 
-			case 2:
-				// No modifications.
+			case LIGHTMODE_INDIRECT_PURE:
 				break;
 
 			default:

--- a/src/utils/vrad/vraddetailprops.cpp
+++ b/src/utils/vrad/vraddetailprops.cpp
@@ -737,32 +737,35 @@ void ComputeIndirectLightingAtPoint( Vector &position, Vector &normal, Vector &o
 			ColorRGBExp32ToVector( *pLightmap, lightmapColor );
 		}
 
-		// The calculation for indirect prop lighting has went through a handful of iterations
+		// The calculation for indirect prop lighting has went through a handful of iterations.
 		// For the sake of compatibility with maps that may be calibrated against the incorrect forms of indirect lightings,
-		// the user may optionally switch to the old methods of indirect prop lighting
+		// the user may optionally switch to the old methods of indirect prop lighting.
+		//
+		// Mode 0: CSGO
+		// This mode factors in only the dot.
+		// The practical result is this ends up being a middleground of Orangebox and TF2 lighting,
+		// and most closely matches indirect lighting on brush lightmaps.
+		//
+		// Mode 1: TF2
+		// TF2 attempted to include falloff using inverse square law.
+		// Unfortunately, this leads to pretty harsh and unnatural bounced light on props.
+		//
+		// Mode 2: Orangebox (and earlier)
+		// Here, indirect lighting simply took the reflectivity and did not factor in falloff or dot.
+		// This created an unnaturally bright result, but this is what TF2 shipped with on release.
 		switch ( g_nIndirectPropLightingMode )
 		{
-			// Mode 0: CSGO
-			// This mode factors in only the dot.
-			// The practical result is this ends up being a middleground of Orangebox and TF2 lighting,
-			// and most closely matches indirect lighting on brush lightmaps
 			case 0:
 			{
 				VectorMultiply( lightmapColor, dot * dtexdata[pTex->texdata].reflectivity, lightmapColor );
 				break;
 			}
-			// Mode 1: TF2
-			// TF2 attempted to include falloff using inverse square law.
-			// Unfortunately, this leads to pretty harsh and unnatural bounced light on props
 			case 1:
 			{
 				float invLengthSqr = 1.0f / ( 1.0f + ( ( vEnd - position ) * surfEnum.m_HitFrac / 128.0 ).LengthSqr() );
 				VectorMultiply( lightmapColor, invLengthSqr * dtexdata[pTex->texdata].reflectivity, lightmapColor );
 				break;
 			}
-			// Mode 2: Orangebox (and earlier)
-			// Here, indirect lighting simply took the reflectivity and did not factor in falloff or dot.
-			// This created an unnaturally bright result, but this is what TF2 shipped with on release.
 			case 2:
 			{
 				VectorMultiply( lightmapColor, dtexdata[pTex->texdata].reflectivity, lightmapColor );

--- a/src/utils/vrad/vraddetailprops.h
+++ b/src/utils/vrad/vraddetailprops.h
@@ -14,6 +14,16 @@
 #include "bspfile.h"
 #include "mathlib/anorms.h"
 
+#define LIGHTMODE_INDIRECT_LAST	(LIGHTMODE_INDIRECT_COUNT - 1)
+
+enum
+{
+	LIGHTMODE_INDIRECT_DOT,
+	LIGHTMODE_INDIRECT_INVSQRLAW,
+	LIGHTMODE_INDIRECT_PURE,
+
+	LIGHTMODE_INDIRECT_COUNT
+};
 
 // Calculate the lighting at whatever surface the ray hits.
 // Note: this ADDS to the values already in color. So if you want absolute


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->
This is slightly more manageable/readable in case I.E. inverse square law gets fixed (or replaced). Or something else needs to be set as the standard 0 value.

Also stops users from putting in bad values, completely skipping reflection multiplication.